### PR TITLE
General cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ serde = { version = "1.0.171", features = ["derive"] }
 reqwest = { version = "0.11", features = ["json", "tokio-native-tls"] }
 regex = "1"
 grcov = "0.8.19"
+serde_json = "1.0.104"
+thiserror = "1.0.44"
 
 [lib]
 name = "tirengine"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tir-engine"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.70"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,7 +14,6 @@ serde = { version = "1.0.171", features = ["derive"] }
 reqwest = { version = "0.11", features = ["json", "tokio-native-tls"] }
 regex = "1"
 grcov = "0.8.19"
-serde_json = "1.0.104"
 thiserror = "1.0.44"
 
 [lib]

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -3,8 +3,9 @@ use dotenv::dotenv;
 use std::env;
 use std::fs::File;
 use std::io::Read;
+use std::path::Path;
 
-pub fn load_env(filename: String) {
+pub fn load_env<P: AsRef<Path>>(filename: P) {
     let _ = dotenv::from_filename(filename);
     dotenv().ok();
 }
@@ -21,28 +22,30 @@ pub fn load_roadmap(roadmap_path: String) -> Vec<Thematic> {
     serde_yaml::from_str(&contents).expect("Failed to parse YAML")
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_load_env() {
-        load_env(String::from("default.env"));
+        load_env("default.env");
         let roadmap_file_path = get_var("ROADMAP_FILE_PATH");
-        assert!(roadmap_file_path.is_some(), "ROADMAP_FILE_PATH doesn't exist");
+        assert!(
+            roadmap_file_path.is_some(),
+            "ROADMAP_FILE_PATH doesn't exist"
+        );
     }
 
     #[test]
     fn test_get_var() {
-        load_env(String::from("default.env"));
+        load_env("default.env");
         let roadmap_file_path = get_var("ROADMAP_FILE_PATH");
         assert_eq!(roadmap_file_path.unwrap(), "./default.roadmap.yml");
     }
-    
+
     #[test]
     fn test_load_env_negative() {
-        load_env(String::from("default.env"));
+        load_env("default.env");
         let roadmap_file_path = get_var("roadmap_file_path");
         assert!(roadmap_file_path.is_none(), "roadmap_file_path does exist");
     }
@@ -57,5 +60,4 @@ mod tests {
     fn test_load_roadmap_negative() {
         let _ = load_roadmap(String::from("./not.exists.yml"));
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,30 +1,32 @@
 mod configuration;
 mod openai;
 mod structs;
-use structs::{AnswerResult, Thematic, Topic};
+use openai::error::TirError;
+use structs::{Answer, Thematic, Topic};
 
 fn get_client() -> openai::GPT {
-    configuration::load_env(String::from(".env"));
+    configuration::load_env(".env");
     let secret_key = configuration::get_var("OPENAI_SK").unwrap();
     openai::GPT::new(secret_key)
 }
 
-pub async fn generate_knowledge() -> Vec<Thematic> {
+pub async fn generate_knowledge() -> Result<Vec<Thematic>, TirError> {
     let client = get_client();
     let roadmap_file_path = configuration::get_var("ROADMAP_FILE_PATH").unwrap();
     let mut roadmap = configuration::load_roadmap(roadmap_file_path);
-    for mut thematic in &mut roadmap {
-        client.generate_knowledge(&mut thematic).await;
+
+    for thematic in &mut roadmap {
+        client.generate_knowledge(thematic).await?;
     }
-    return roadmap;
+    Ok(roadmap)
 }
 
-pub async fn evaluate_answer(answer: String, topic: Topic) -> AnswerResult {
+pub async fn evaluate_answer(answer: String, topic: Topic) -> Result<Answer, TirError> {
     let client = get_client();
     client.evaluate_answer(answer, topic).await
 }
 
-pub async fn correct_explanation(correction: String, mut topic: &mut Topic) {
+pub async fn correct_explanation(correction: String, topic: &mut Topic) -> Result<(), TirError> {
     let client = get_client();
-    client.correct_explanation(correction, &mut topic).await
+    client.correct_explanation(correction, topic).await
 }

--- a/src/openai/client.rs
+++ b/src/openai/client.rs
@@ -106,8 +106,7 @@ impl Client {
             .header(reqwest::header::CONTENT_TYPE, "application/json")
             .json(&request)
             .send()
-            .await?
-            .json::<Either<OpenAIResponse, OpenAIError>>()
+            .await?.json::<Either<OpenAIResponse, OpenAIError>>()
             .await;
 
         // If we get back an error JSON from OpenAI, parse and keep that around in the `Err` variant.
@@ -159,9 +158,10 @@ mod tests {
         configuration::load_env(".env");
         let secret_key = configuration::get_var("OPENAI_SK").unwrap();
         let client = Client::new(secret_key);
+        let result = client.get_ai_response(vec![], 0).await;
         assert!(matches!(
-            client.get_ai_response(vec![], 0).await,
-            Err(TirError::EmptyChoiceVec)
+            result,
+            Err(TirError::OpenAIError(_))
         ));
     }
 }

--- a/src/openai/client.rs
+++ b/src/openai/client.rs
@@ -155,11 +155,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "missing field `choices`")]
     async fn test_get_ai_response_negative() {
         configuration::load_env(".env");
         let secret_key = configuration::get_var("OPENAI_SK").unwrap();
         let client = Client::new(secret_key);
-        client.get_ai_response(vec![], 0).await.unwrap();
+        assert!(matches!(
+            client.get_ai_response(vec![], 0).await,
+            Err(TirError::EmptyChoiceVec)
+        ));
     }
 }

--- a/src/openai/client.rs
+++ b/src/openai/client.rs
@@ -1,23 +1,56 @@
-use reqwest;
-use serde::{Deserialize, Serialize};
-use std::fmt::*;
+use std::borrow::Cow;
 
-const OPENAI_URL: &'static str = "https://api.openai.com/v1/chat/completions";
+use serde::{Deserialize, Serialize};
+
+use super::error::{OpenAIError, TirError};
+
+const OPENAI_URL: &str = "https://api.openai.com/v1/chat/completions";
+const GPT_35_TURBO: &str = "gpt-3.5-turbo";
 
 #[derive(Debug, Serialize)]
 pub struct OpenAIRequestMessage {
-    pub role: String,
-    pub content: String,
+    // Technically both `role` and `content` can be an owned `String`, or a `&str` string reference.
+    // The `std::borrow::Cow` type will ensure we don't allocate when it's not necessary.
+    pub role: Cow<'static, str>,
+    pub content: Cow<'static, str>,
+}
+
+impl OpenAIRequestMessage {
+    // By accepting `impl Into<Cow<'static, str>>`, we may accept `String`s or `&str`s too.
+    // This is just makes it more comfortable to construct this type.
+    pub(crate) fn from_parts(
+        role: impl Into<Cow<'static, str>>,
+        content: impl Into<Cow<'static, str>>,
+    ) -> Self {
+        Self {
+            role: role.into(),
+            content: content.into(),
+        }
+    }
+
+    pub(crate) fn with_system_role(content: impl Into<Cow<'static, str>>) -> Self {
+        Self {
+            role: "system".into(),
+            content: content.into(),
+        }
+    }
+
+    pub(crate) fn with_user_role(content: impl Into<Cow<'static, str>>) -> Self {
+        Self {
+            role: "user".into(),
+            content: content.into(),
+        }
+    }
 }
 
 #[derive(Serialize)]
 struct OpenAIRequest {
     messages: Vec<OpenAIRequestMessage>,
     max_tokens: u32,
-    model: String,
+    model: &'static str,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct OpenAIResponse {
     pub choices: Vec<Choice>,
 }
@@ -35,32 +68,55 @@ pub struct ChoiceMessage {
 
 pub struct Client {
     pub secret_key: String,
+    // To avoid creating a new reqwest client on every call to `get_ai_response`, let's store it here.
+    reqwest_client: reqwest::Client,
+}
+
+// A dirty trick to be able to deserialize one of two types relatively seamlessly.
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+enum Either<L, R> {
+    Left(L),
+    Right(R),
 }
 
 impl Client {
+    pub fn new(secret_key: String) -> Self {
+        let reqwest_client = reqwest::Client::new();
+        Self {
+            secret_key,
+            reqwest_client,
+        }
+    }
+
     pub async fn get_ai_response(
         &self,
         messages: Vec<OpenAIRequestMessage>,
         max_tokens: u32,
-    ) -> OpenAIResponse {
-        let client = reqwest::Client::new();
+    ) -> Result<OpenAIResponse, TirError> {
         let request = OpenAIRequest {
             messages,
             max_tokens,
-            model: "gpt-3.5-turbo".to_string(),
+            model: GPT_35_TURBO,
         };
-        let response = client
+        let response = self
+            .reqwest_client
             .post(OPENAI_URL)
-            .header("Authorization", format!("Bearer {}", self.secret_key)) // Replace "YOUR_OPENAI_KEY" with your actual key
-            .header("Content-Type", "application/json")
+            .bearer_auth(&self.secret_key)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
             .json(&request)
             .send()
-            .await
-            .unwrap()
-            .json::<OpenAIResponse>()
+            .await?
+            .json::<Either<OpenAIResponse, OpenAIError>>()
             .await;
 
-        return response.unwrap();
+        // If we get back an error JSON from OpenAI, parse and keep that around in the `Err` variant.
+        // We'll have better analytics, and we may save some debugging time too.
+        match response {
+            Ok(Either::Left(l)) => Ok(l),
+            Ok(Either::Right(r)) => Err(TirError::OpenAIError(r)),
+            Err(e) => Err(TirError::Request(e)),
+        }
     }
 }
 
@@ -71,50 +127,39 @@ mod tests {
     use tokio::test;
 
     #[test]
-    async fn test_initialize_client() {
-        let secret_key = String::from("VERY_SECRET_KEY");
-        let client = Client {
-            secret_key: secret_key.clone(),
-        };
-        assert_eq!(client.secret_key, secret_key);
-    }
-
-    #[test]
     async fn test_get_ai_response() {
-        configuration::load_env(String::from(".env"));
+        configuration::load_env(".env");
         let secret_key = configuration::get_var("OPENAI_SK").unwrap();
-        let client = Client {
-            secret_key: secret_key.clone(),
-        };
-        let response = client.get_ai_response(
-            vec![OpenAIRequestMessage {
-                role: String::from("system"),
-                content: String::from("2+2? Please send only the answer number"),
-            }],
-            1,
-        ).await;
+        let client = Client::new(secret_key);
+        let response = client
+            .get_ai_response(
+                vec![OpenAIRequestMessage::with_system_role(
+                    "2+2? Please send only the answer number",
+                )],
+                1,
+            )
+            .await
+            .unwrap();
         assert_eq!(response.choices.len(), 1);
-        let choice = response.choices.first();
-        match choice {
-            Some(_choice) => assert_eq!(_choice.message.content, "4"),
-            None => assert!(false)
-        }
+        assert_eq!(
+            response
+                .choices
+                .first()
+                .unwrap()
+                .message
+                .content
+                .parse::<usize>()
+                .unwrap(),
+            4
+        );
     }
-
 
     #[test]
     #[should_panic(expected = "missing field `choices`")]
     async fn test_get_ai_response_negative() {
-        configuration::load_env(String::from(".env"));
+        configuration::load_env(".env");
         let secret_key = configuration::get_var("OPENAI_SK").unwrap();
-        let client = Client {
-            secret_key: secret_key.clone(),
-        };
-        let _ = client.get_ai_response(
-            vec![],
-            0,
-        ).await;
+        let client = Client::new(secret_key);
+        client.get_ai_response(vec![], 0).await.unwrap();
     }
-
-    
 }

--- a/src/openai/error.rs
+++ b/src/openai/error.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+
+// A custom error enum. Not strictly necessary, but as you grow your app, more and more error variants will show up.
+// The `thiserror` crate makes this pleasant to write and to group them.
+// It this is too heavy, the `anyhow` create is also an option to consider (it's more often used for general "application" code)
+#[derive(thiserror::Error, Debug)]
+pub enum TirError {
+    #[error("request error: {0}")]
+    Request(#[from] reqwest::Error),
+    #[error("OpenAI error: {0:?}")]
+    OpenAIError(OpenAIError),
+    #[error("choice vector was empty")]
+    EmptyChoiceVec,
+}
+
+// An error JSON we may get back from OpenAI, for example:
+//
+//    {"error": {"code": "something", "message": "something else"}}
+//
+// Note: I haven't looked at OpenAI documentation to validate this scheme. Take this with a grain of salt.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct OpenAIError {
+    pub error: OpenAiErrorDetails,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct OpenAiErrorDetails {
+    pub code: String,
+    pub message: Option<String>,
+}

--- a/src/openai/error.rs
+++ b/src/openai/error.rs
@@ -20,11 +20,11 @@ pub enum TirError {
 // Note: I haven't looked at OpenAI documentation to validate this scheme. Take this with a grain of salt.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct OpenAIError {
-    pub error: OpenAiErrorDetails,
+    pub error: Option<OpenAiErrorDetails>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct OpenAiErrorDetails {
-    pub code: String,
+    pub code: Option<String>,
     pub message: Option<String>,
 }

--- a/src/openai/mod.rs
+++ b/src/openai/mod.rs
@@ -1,11 +1,20 @@
-use self::client::{Client, OpenAIRequestMessage, OpenAIResponse};
-use crate::structs::{AnswerResult, Thematic, Topic};
+use self::{
+    client::{Client, OpenAIRequestMessage, OpenAIResponse},
+    error::TirError,
+};
+use crate::structs::{Answer, Thematic, Topic};
 use regex::Regex;
 mod client;
+pub mod error;
+use std::sync::OnceLock;
 
 const GK_START_PROMPT: &str = "You are my mentor and also a senior software engineer.";
 const EA_START_PROMPT: &str = "You are my mentor and also a senior software engineer.";
 const CE_START_PROMPT: &str = "You are my mentor and also a senior software engineer.";
+
+// Regex compilation is expensive - let's do it only once. The first run of `GPT::evaluate_answer` will initialize this.
+// For details: https://docs.rs/regex/latest/regex/#avoid-re-compiling-regexes-especially-in-a-loop
+static RE: OnceLock<Regex> = OnceLock::new();
 
 pub struct GPT {
     client: Client,
@@ -13,86 +22,109 @@ pub struct GPT {
 
 impl GPT {
     pub fn new(secret_key: String) -> Self {
-        let client = Client { secret_key };
-
-        Self { client }
+        Self {
+            client: Client::new(secret_key),
+        }
     }
 
-    async fn ask(&self, messages: Vec<OpenAIRequestMessage>) -> OpenAIResponse {
-        return self.ask_with_limits(messages, 500).await; // TODO configurate it
+    async fn ask(&self, messages: Vec<OpenAIRequestMessage>) -> Result<OpenAIResponse, TirError> {
+        self.ask_with_limits(messages, 500).await // TODO configurate it
     }
 
     async fn ask_with_limits(
         &self,
         messages: Vec<OpenAIRequestMessage>,
         max_tokens: u32,
-    ) -> OpenAIResponse {
-        return self.client.get_ai_response(messages, max_tokens).await;
+    ) -> Result<OpenAIResponse, TirError> {
+        self.client.get_ai_response(messages, max_tokens).await
     }
 
-    pub async fn generate_knowledge(&self, thematic: &mut Thematic) {
-        for mut topic in &mut thematic.topics {
+    pub async fn generate_knowledge(&self, thematic: &mut Thematic) -> Result<(), TirError> {
+        for topic in &mut thematic.topics {
             let messages: Vec<OpenAIRequestMessage> = vec![
-                    OpenAIRequestMessage {
-                        role:String::from("system"),
-                        content: GK_START_PROMPT.to_string(),
-                    },
-                    OpenAIRequestMessage {
-                        role: String::from("user"),
-                        content: format!(
-                            "Explain me the {} topic ({}) in 500 characters please, I am a very beginner in software development.",
-                            topic.title, thematic.title
-                        ),
-                    },
-                ];
-            let response = self.ask(messages).await;
-            topic.explanation = Some(response.choices.first().unwrap().message.content.clone());
+                OpenAIRequestMessage::with_system_role(GK_START_PROMPT),
+                OpenAIRequestMessage::with_user_role(format!(
+                        "Explain me the {} topic ({}) in 500 characters please, I am a very beginner in software development.",
+                        topic.title, thematic.title
+                    ))
+            ];
+            let response = self.ask(messages).await?;
+            // If there's no first element in `choices`, immediately bubble up with an error.
+            // Feel free to change this: I don't know whether this is the right thing to do based on business logic.
+            // `unwrap`ing however should definitely be avoided.
+            //
+            // Note: if you'd like to set the `explanation` to `None` if there was nothing in `choices`, you may write:
+            //
+            // topic.explanation = response
+            //     .choices
+            //     .first()
+            //     .map(|choice| choice.message.content.clone())
+            topic.explanation = Some(
+                response
+                    .choices
+                    .first()
+                    .ok_or(TirError::EmptyChoiceVec)?
+                    .message
+                    .content
+                    .clone(),
+            );
         }
+        Ok(())
     }
 
-    pub async fn evaluate_answer(&self, answer: String, topic: Topic) -> AnswerResult {
+    pub async fn evaluate_answer(&self, answer: String, topic: Topic) -> Result<Answer, TirError> {
         let messages: Vec<OpenAIRequestMessage> = vec![
-            OpenAIRequestMessage {
-                role: String::from("system"),
-                content: EA_START_PROMPT.to_string(),
-            },
-            OpenAIRequestMessage {
-                role: String::from("user"),
-                content: format!(
+            OpenAIRequestMessage::with_system_role(EA_START_PROMPT),
+            OpenAIRequestMessage::with_user_role(format!(
                     "You asked me to explain the '{}' topic, please rate my answer between 1-10 and put your score between two % sign (for example: I would rate your answer a %6% out of 10). My answer: '{}'",
                     topic.title, answer
-                ),
-            },
+                ))
         ];
-        let response = self.ask(messages).await;
-        let result_text: &str =
-            &Some(response.choices.first().unwrap().message.content.clone()).unwrap();
-        let re = Regex::new(r"%(\d+)%").unwrap();
-        let caps = re.captures(result_text).unwrap();
+        let response = self.ask(messages).await?;
+        let result_text = &response
+            .choices
+            .first()
+            .ok_or(TirError::EmptyChoiceVec)?
+            .message
+            .content;
+        let caps = RE
+            .get_or_init(|| Regex::new(r"%(\d+)%").unwrap())
+            .captures(result_text)
+            .unwrap();
         let score: u8 = caps[1].parse().unwrap();
-        let explanation = re.replace(result_text, &caps[1]);
-        AnswerResult {
+        let explanation = RE
+            .get()
+            .expect("initialized above")
+            .replace(result_text, &caps[1]);
+        Ok(Answer {
             score,
             explanation: explanation.to_string(),
-        }
+        })
     }
 
-    pub async fn correct_explanation(&self, correction: String, topic: &mut Topic) {
+    pub async fn correct_explanation(
+        &self,
+        correction: String,
+        topic: &mut Topic,
+    ) -> Result<(), TirError> {
         let messages: Vec<OpenAIRequestMessage> = vec![
-            OpenAIRequestMessage {
-                role: String::from("system"),
-                content: CE_START_PROMPT.to_string(),
-            },
-            OpenAIRequestMessage {
-                role: String::from("user"),
-                content: format!(
+            OpenAIRequestMessage::with_system_role(CE_START_PROMPT),
+            OpenAIRequestMessage::with_user_role(format!(
                     "For the '{}' topic explanation you gave me this answer: '{}'. Please correct it with this instruction: '{}'",
                     topic.title, topic.explanation.as_ref().unwrap(), correction
-                ),
-            },
+                ))
         ];
-        let response = self.ask(messages).await;
-        topic.explanation = Some(response.choices.first().unwrap().message.content.clone());
+        let response = self.ask(messages).await?;
+        topic.explanation = Some(
+            response
+                .choices
+                .first()
+                .ok_or(TirError::EmptyChoiceVec)?
+                .message
+                .content
+                .clone(),
+        );
+        Ok(())
     }
 }
 
@@ -111,18 +143,18 @@ mod tests {
 
     #[test]
     async fn test_ask_response_length() {
-        configuration::load_env(String::from(".env"));
+        configuration::load_env(".env");
         let secret_key = configuration::get_var("OPENAI_SK").unwrap();
         let gpt_client = GPT::new(secret_key.clone());
         let response = gpt_client
             .ask_with_limits(
-                vec![OpenAIRequestMessage {
-                    role: String::from("system"),
-                    content: String::from("Write one word only"),
-                }],
+                vec![OpenAIRequestMessage::with_system_role(
+                    "Write one word only",
+                )],
                 1,
             )
-            .await;
+            .await
+            .unwrap();
         let choice = response.choices.first().unwrap();
         let word_count = choice.message.content.split_ascii_whitespace().count();
         assert_eq!(word_count, 1);
@@ -130,26 +162,25 @@ mod tests {
 
     #[test]
     async fn test_generate_knowledge() {
-        configuration::load_env(String::from(".env"));
+        configuration::load_env(".env");
         let secret_key = configuration::get_var("OPENAI_SK").unwrap();
-        println!("{:?}-",secret_key);
         let client = GPT::new(secret_key);
         let mut thematic = Thematic {
-            title: String::from("Desing patterns"),
+            title: String::from("Design patterns"),
             topics: vec![Topic {
                 title: String::from("Singleton"),
                 explanation: Some(String::from("")),
             }],
         };
 
-        client.generate_knowledge(&mut thematic).await;
+        client.generate_knowledge(&mut thematic).await.unwrap();
         for topic in thematic.topics {
             assert!(topic.explanation.is_some());
         }
     }
     #[test]
     async fn correct_explanation() {
-        configuration::load_env(String::from(".env"));
+        configuration::load_env(".env");
         let secret_key = configuration::get_var("OPENAI_SK").unwrap();
         let client = GPT::new(secret_key);
         let explanation = String::from("The Singleton pattern is a design pattern that ensures only one instance of a class is created throughout the application. It is useful when you want to restrict the instantiation of a class to a single object and ensure that no other object can create additional instances.");
@@ -165,13 +196,14 @@ mod tests {
                 ),
                 &mut topic,
             )
-            .await;
+            .await
+            .unwrap();
         assert_ne!(topic.explanation.unwrap(), explanation);
     }
 
     #[test]
     async fn test_evaluate_answer() {
-        configuration::load_env(String::from(".env"));
+        configuration::load_env(".env");
         let secret_key = configuration::get_var("OPENAI_SK").unwrap();
         let client = GPT::new(secret_key);
 
@@ -180,7 +212,7 @@ mod tests {
             explanation: Some(String::from("")),
         };
 
-        let result = client.evaluate_answer(String::from("Singleton is a design pattern in the software development when you only have one instance from a Class."), topic).await;
+        let result = client.evaluate_answer(String::from("Singleton is a design pattern in the software development when you only have one instance from a Class."), topic).await.unwrap();
         assert!((1..=10).contains(&result.score));
         assert!(result.explanation.len() > 5);
     }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,6 +1,5 @@
-
 #[derive(Debug, serde::Deserialize, Clone)]
-pub struct AnswerResult {
+pub struct Answer {
     pub score: u8,
     pub explanation: String,
 }


### PR DESCRIPTION
Made some general cleanup. These cleanups include:
- Avoid allocating `String`s where it's not necessary.
- Fallible functions now return `Result`s, and they're bubbled up via the `?` operator. This means many `unwrap`s are now purged.
- Added the `thiserror` crate for a custom error enum.
- If OpenAI sends an error JSON back, parse that one too, and keep it in the `Err` variant.
- Keep around the `reqwest::Client`, so we don't need to initialize it on every call.
- Regex is now lazily initialized once, on first run.
- Some general code-quality stuff: renaming, added utility methods, changed some type signatures.

There are many noisy comments explaining stuff - I just wanted to provide some context, but these can be removed.
This PR includes some Rust features that weren't present in the code before, so feel free to close it if the changes are too crazy. :zany_face: 