### PR TITLE
Exclude grcov dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.70"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 tokio = { version = "1.29.1", features = ["full"] }
 dotenv = "0.15.0"
@@ -13,7 +11,6 @@ serde_yaml = "0.9.24"
 serde = { version = "1.0.171", features = ["derive"] }
 reqwest = { version = "0.11", features = ["json", "tokio-native-tls"] }
 regex = "1"
-grcov = "0.8.19"
 thiserror = "1.0.44"
 
 [lib]


### PR DESCRIPTION
Removed the `grcov` dependency because:
  - triggered a [critical CVE alert](https://cwe.mitre.org/data/definitions/843.html) for me because of a transitive dependency
  - it's not used anyway

For code coverage, probably use [cargo-tarpaulin](https://github.com/xd009642/tarpaulin).